### PR TITLE
Fixed an issue, when used without Spree::MultiDomain

### DIFF
--- a/lib/spree/search/solr.rb
+++ b/lib/spree/search/solr.rb
@@ -32,7 +32,7 @@ module Spree::Search
         full_query += " AND (#{taxons_query})"
       end
       
-      full_query += " AND store_ids:(#{current_store_id})" if current_store_id
+      full_query += " AND store_ids:(#{@properties[:current_store_id]})" if @properties[:current_store_id]
 
       # Rails.logger.info "Solr Query: #{full_query}\nOptions: #{search_options}"
 


### PR DESCRIPTION
Without Spree::Multidomain, there is no `current_store_id` and an error is thrown.

Now using the `@properties` hash to safely access this id if present.

(Spree::Multidomain uses the `@properties` hash to pass variables to `get_products_conditions_for`.)
