### PR TITLE
Fixed an issue with uninitialized @searcher.suggest

### DIFF
--- a/lib/spree/search/solr.rb
+++ b/lib/spree/search/solr.rb
@@ -58,6 +58,7 @@ module Spree::Search
 
     def prepare(params)
       super
+      @properties[:suggest] = nil
       @properties[:facets] = params[:facets] || {}
       @properties[:available_facets] = []
       @properties[:manage_pagination] = false


### PR DESCRIPTION
When submitting the search form with an empty query `@searcher.suggest` wasn’t available.
